### PR TITLE
Renamed parent POM for DataStax-driver-3 as azure-cosmos-cassandra-driver-3

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -8,12 +8,12 @@ Licensed under the MIT License.
 
   <modelVersion>4.0.0</modelVersion>
 
-  <artifactId>azure-cosmos-cassandra-extensions.examples</artifactId>
+  <artifactId>azure-cosmos-cassandra-driver-3-examples</artifactId>
   <packaging>jar</packaging>
   <version>0.13.0</version>
 
   <parent>
-    <artifactId>azure-cosmos-cassandra-extensions.parent</artifactId>
+    <artifactId>azure-cosmos-cassandra-driver-3</artifactId>
     <groupId>com.microsoft.azure</groupId>
     <version>0.13.0</version>
   </parent>

--- a/package/pom.xml
+++ b/package/pom.xml
@@ -22,6 +22,12 @@ Licensed under the MIT License.
     <dependency>
       <artifactId>cassandra-driver-core</artifactId>
       <groupId>com.datastax.cassandra</groupId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
@@ -41,11 +47,6 @@ Licensed under the MIT License.
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/package/pom.xml
+++ b/package/pom.xml
@@ -13,7 +13,7 @@ Licensed under the MIT License.
   <version>0.13.0</version>
 
   <parent>
-    <artifactId>azure-cosmos-cassandra-extensions.parent</artifactId>
+    <artifactId>azure-cosmos-cassandra-driver-3</artifactId>
     <groupId>com.microsoft.azure</groupId>
     <version>0.13.0</version>
   </parent>

--- a/pom.xml
+++ b/pom.xml
@@ -45,11 +45,11 @@ Licensed under the MIT License.
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <javadoc.options/>
     <!-- Main dependency version numbers -->
-    <version.cassandra-driver>3.10.2</version.cassandra-driver>
+    <version.cassandra-driver>[3.8, 3.11)</version.cassandra-driver>
+    <version.slf4j-api>[1.7.0, 1.8.0-alpha0)</version.slf4j-api>
     <!-- Test dependency version numbers -->
     <version.assertj-core>3.18.0</version.assertj-core>
     <version.log4j>2.13.3</version.log4j>
-    <version.slf4j-api>1.7.30</version.slf4j-api>
     <version.spotbugs>4.1.4</version.spotbugs>
     <version.testng>7.3.0</version.testng>
   </properties>
@@ -92,19 +92,16 @@ Licensed under the MIT License.
         <groupId>org.assertj</groupId>
         <artifactId>assertj-core</artifactId>
         <version>${version.assertj-core}</version>
-        <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
-        <scope>test</scope>
         <version>${version.slf4j-api}</version>
       </dependency>
       <dependency>
         <groupId>org.testng</groupId>
         <artifactId>testng</artifactId>
         <version>${version.testng}</version>
-        <scope>test</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@ Licensed under the MIT License.
   </description>
   <url>https://docs.microsoft.com/en-us/azure/cosmos-db/cassandra-introduction</url>
 
-  <artifactId>azure-cosmos-cassandra-extensions.parent</artifactId>
+  <artifactId>azure-cosmos-cassandra-driver-3</artifactId>
   <groupId>com.microsoft.azure</groupId>
   <packaging>pom</packaging>
   <version>0.13.0</version>


### PR DESCRIPTION
This establishes an indirect link between the azure-cosmos-cassandra-extensions package and the DataStax driver version.

Also: 

- Renamed the examples package as azure-cosmos-cassandra-driver-3-examples for consistency with azure-cosmos-cassandra-driver-4-examples.

  The extensions package will not been renamed because that would break customers who have taken a dependency on its current name: azure-cosmos-cassandra-extensions. We do not publish the examples package so there is no issue with changing the examples package name.

- Tweaked package dependencies in prep for adding logging and testing three versions back from the current version.
  
  The extensions package now specifies that it requires specific version ranges for datastax-java-driver-3 and slf4j. The ranges indicate the versions major.minor versions that we've tested.