### PR TITLE
[CHORE] Rename parent pom as azure-cosmos-cassandra-driver-3

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -10,12 +10,12 @@ Licensed under the MIT License.
 
   <artifactId>azure-cosmos-cassandra-driver-3-examples</artifactId>
   <packaging>jar</packaging>
-  <version>0.13.0</version>
+  <version>0.14.0</version>
 
   <parent>
     <artifactId>azure-cosmos-cassandra-driver-3</artifactId>
     <groupId>com.microsoft.azure</groupId>
-    <version>0.13.0</version>
+    <version>0.14.0</version>
   </parent>
 
   <dependencies>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -8,12 +8,12 @@ Licensed under the MIT License.
 
   <modelVersion>4.0.0</modelVersion>
 
-  <artifactId>azure-cosmos-cassandra-extensions.examples</artifactId>
+  <artifactId>azure-cosmos-cassandra-driver-3-examples</artifactId>
   <packaging>jar</packaging>
   <version>0.13.0</version>
 
   <parent>
-    <artifactId>azure-cosmos-cassandra-extensions.parent</artifactId>
+    <artifactId>azure-cosmos-cassandra-driver-3</artifactId>
     <groupId>com.microsoft.azure</groupId>
     <version>0.13.0</version>
   </parent>

--- a/package/CHANGELOG.md
+++ b/package/CHANGELOG.md
@@ -1,7 +1,25 @@
 ## Release History
 
-## 0.13.0
+## 0.14.0
+
 This is a maintenance release that:
+
+* Adds debug logging to `CosmosLoadBalancingPolicy`.
+  
+  We now log the hosts that the load balancing policy offers as they're offered. This is useful for debugging routing 
+  issues.
+
+* Renames the parent pom for azure-cosmos-cassandra-extensions as azure-cosmos-cassandra-driver-3.
+
+  This is to trace the extensions for datastax-java-driver-3 back to that version of the driver. This is in anticipation
+  of forthcoming extensions for datastax-java-driver-4. It's just the parent pom name that is changed in this release, 
+  not the extensions package name. This is to avoid breaking existing dependencies. You should not need to change 
+  anything other than the version number to take a dependency on this release.
+  
+## 0.13.0
+
+This is a maintenance release that:
+
 * Resolves some bugs.
 * Improves the test code.
 * Adds support for Azure Pipelines to build, test, and subsequently publish the package.

--- a/package/pom.xml
+++ b/package/pom.xml
@@ -22,6 +22,12 @@ Licensed under the MIT License.
     <dependency>
       <artifactId>cassandra-driver-core</artifactId>
       <groupId>com.datastax.cassandra</groupId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
@@ -41,11 +47,6 @@ Licensed under the MIT License.
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/package/pom.xml
+++ b/package/pom.xml
@@ -13,7 +13,7 @@ Licensed under the MIT License.
   <version>0.13.0</version>
 
   <parent>
-    <artifactId>azure-cosmos-cassandra-extensions.parent</artifactId>
+    <artifactId>azure-cosmos-cassandra-driver-3</artifactId>
     <groupId>com.microsoft.azure</groupId>
     <version>0.13.0</version>
   </parent>

--- a/package/pom.xml
+++ b/package/pom.xml
@@ -10,12 +10,12 @@ Licensed under the MIT License.
 
   <artifactId>azure-cosmos-cassandra-extensions</artifactId>
   <packaging>jar</packaging>
-  <version>0.13.0</version>
+  <version>0.14.0</version>
 
   <parent>
     <artifactId>azure-cosmos-cassandra-driver-3</artifactId>
     <groupId>com.microsoft.azure</groupId>
-    <version>0.13.0</version>
+    <version>0.14.0</version>
   </parent>
 
   <dependencies>

--- a/package/src/main/java/com/microsoft/azure/cosmos/cassandra/CosmosLoadBalancingPolicy.java
+++ b/package/src/main/java/com/microsoft/azure/cosmos/cassandra/CosmosLoadBalancingPolicy.java
@@ -80,7 +80,7 @@ public final class CosmosLoadBalancingPolicy implements LoadBalancingPolicy {
         this.dnsExpirationInSeconds = dnsExpirationInSeconds;
 
         this.index = new AtomicInteger();
-        this.lastDnsLookupTime = Long.MAX_VALUE;
+        this.lastDnsLookupTime = Long.MIN_VALUE;
     }
 
     // endregion

--- a/package/src/main/java/com/microsoft/azure/cosmos/cassandra/CosmosLoadBalancingPolicy.java
+++ b/package/src/main/java/com/microsoft/azure/cosmos/cassandra/CosmosLoadBalancingPolicy.java
@@ -488,21 +488,25 @@ public final class CosmosLoadBalancingPolicy implements LoadBalancingPolicy {
                 if (this.remainingRead > 0 && readRequest) {
                     this.remainingRead--;
                     host = this.readHosts.get(this.idx++ % this.readHosts.size());
-                    LOG.debug("attempting read request in read datacenter at {}", host);
+                    LOG.debug("offering host {} for read request in read datacenter", host);
                     return host;
                 }
 
                 if (this.remainingWrite > 0) {
                     this.remainingWrite--;
                     host = this.writeHosts.get(this.idx++ % this.writeHosts.size());
-                    LOG.debug("attempting {} request in write datacenter at {}", readRequest ? "read" : "write", host);
+                    LOG.debug("offering host {} for {} request in write datacenter",
+                        host,
+                        readRequest ? "read" : "write");
                     return host;
                 }
 
                 if (this.remainingRemote > 0) {
                     this.remainingRemote--;
                     host = this.remoteHosts.get(this.idx++ % this.remoteHosts.size());
-                    LOG.debug("attempting {} request in remote datacenter at {}", readRequest ? "read" : "write", host);
+                    LOG.debug("offering host {} for {} request in remote datacenter",
+                        host,
+                        readRequest ? "read" : "write");
                     return host;
                 }
 

--- a/pom.xml
+++ b/pom.xml
@@ -45,11 +45,11 @@ Licensed under the MIT License.
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <javadoc.options/>
     <!-- Main dependency version numbers -->
-    <version.cassandra-driver>3.10.2</version.cassandra-driver>
+    <version.cassandra-driver>[3.8, 3.11)</version.cassandra-driver>
+    <version.slf4j-api>[1.7.0, 1.8.0-alpha0)</version.slf4j-api>
     <!-- Test dependency version numbers -->
     <version.assertj-core>3.18.0</version.assertj-core>
     <version.log4j>2.13.3</version.log4j>
-    <version.slf4j-api>1.7.30</version.slf4j-api>
     <version.spotbugs>4.1.4</version.spotbugs>
     <version.testng>7.3.0</version.testng>
   </properties>
@@ -92,19 +92,16 @@ Licensed under the MIT License.
         <groupId>org.assertj</groupId>
         <artifactId>assertj-core</artifactId>
         <version>${version.assertj-core}</version>
-        <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
-        <scope>test</scope>
         <version>${version.slf4j-api}</version>
       </dependency>
       <dependency>
         <groupId>org.testng</groupId>
         <artifactId>testng</artifactId>
         <version>${version.testng}</version>
-        <scope>test</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@ Licensed under the MIT License.
   <artifactId>azure-cosmos-cassandra-driver-3</artifactId>
   <groupId>com.microsoft.azure</groupId>
   <packaging>pom</packaging>
-  <version>0.13.0</version>
+  <version>0.14.0</version>
 
   <developers>
     <developer>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@ Licensed under the MIT License.
   </description>
   <url>https://docs.microsoft.com/en-us/azure/cosmos-db/cassandra-introduction</url>
 
-  <artifactId>azure-cosmos-cassandra-extensions.parent</artifactId>
+  <artifactId>azure-cosmos-cassandra-driver-3</artifactId>
   <groupId>com.microsoft.azure</groupId>
   <packaging>pom</packaging>
   <version>0.13.0</version>


### PR DESCRIPTION
This is to trace back the extensions for datastax-java-driver-3 as we do for datastax-java-driver-4 *without* breaking current consumers. It's just the parent pom name that changed, not the package name.

ALSO:

- [X] Added some debug logging to `CosmosLoadBalancingPolicy`
  
  We now log the hosts that the load balancing policy offers as they're offered. This is useful for debugging routing issues.

- [X] Ran automated code cleanup on `CosmosLoadBalancingPolicy`.
  
  This is to eliminate a few IntelliJ warning messages.

- [X] Bumped version number to 0.14.0 and updated CHANGELOG.md.

  I am bumping the minor version number due to the parent pom name change.
