### PR TITLE
[CHORE] Release Azure Cosmos Cassandra Extensions for DataStax Java Driver 4

### DIFF
--- a/Release-instructions.md
+++ b/Release-instructions.md
@@ -1,0 +1,25 @@
+# Azure Cosmos Cassandra Extensions for DataStax Java Driver 4 for Apache Cassandra
+## Release instructions
+
+- [ ] Create a release branch based on develop/java-driver-4.
+      ```bash
+      git pull --all
+      git checkout develop/java-driver-4
+      git checkout -b release/java-driver-4/$version
+      ```
+
+- [ ] Update these `package` files:
+
+      * package/CHANGELOG.md
+      * package/KNOWN_ISSUES.md
+      * package/README.md
+
+- [ ] Bump the version numbers in:
+
+      * pom.xml
+      * examples/pom.xml
+      * package/pom.xml
+      
+- [ ] Push your changes and submit a release PR against the code on develop/java-driver-4.
+
+- [ ] When your PR is complete, publish the release artifacts from the CI build to the Maven Repository.

--- a/package/CHANGELOG.md
+++ b/package/CHANGELOG.md
@@ -2,4 +2,4 @@
 
 ## 0.1.0-beta.1
 
-This is the first preview release of the Azure Cosmos Extensions for DataStax Java Driver 4 for Apache Cassandra. Get started using this package by taking a look at `README.md`.
+This is the first preview release of the Azure Cosmos Extensions for DataStax Java Driver 4 for Apache Cassandra. Get started using this package by reviewing `README.md`.

--- a/package/KNOWN_ISSUES.md
+++ b/package/KNOWN_ISSUES.md
@@ -35,10 +35,9 @@ set -o errexit -o nounset
 # Variables
 ###########
 
-declare -r script_root="$(cd "$(dirname "$0")" && pwd)"
 declare -r script_name="$(basename "$0")"
 
-# Update these variables to your liking
+# Update these variables to your liking (they cannot be changed from the command line)
 
 declare -r cacerts_storepath=~/.config/truststore.p12
 declare -r cacerts_storepass=unprotected
@@ -48,19 +47,22 @@ declare -r cacerts_storetype=pkcs12
 # Functions
 ###########
 
-function usage {
-
-    man "${script_name}"
-    exit 0
-}
-
 function error {
-    echo "${script_name} error: $2" 1>&2
+    echo "[$(date --iso-8601=seconds)] ${script_name} error: $2" 1>&2
     exit $1
 }
 
 function note {
     echo "[$(date --iso-8601=seconds)] ${script_name} note: $1" 1>&2
+}
+
+function usage {
+
+    echo "${script_name} --host <hostname> --port <port-number> --name <alias>"
+    echo "  host  DNS name or IP address."
+    echo "  port  Port number."
+    echo "  name  An alias for the certificate entry in the truststore (default: \$host:\$port")
+    exit 0
 }
 
 [[ $OSTYPE != cygwin ]] || error 1 "cygwin is unsupported"
@@ -95,8 +97,8 @@ while [[ $1 != '--' ]]; do
 done
 
 [[ ! -z ${host:-} ]] || error 1 "value for host is required"
-[[ ! -z ${port:-} ]] || declare -r port="8081"
-[[ ! -z ${name:-} ]] || declare -r name="https://$host:$port/"
+[[ ! -z ${port:-} ]] || error 1 "value for port is required"
+[[ ! -z ${name:-} ]] || declare -r name="$host:$port/"
 
 ###########
 # Main

--- a/package/README.md
+++ b/package/README.md
@@ -1,13 +1,20 @@
 # Azure Cosmos Extensions for DataStax Java Driver 4 for Apache Cassandra
 
-This package provides extensions and a `reference.conf` file for correctly and efficiently accessing a Cosmos DB Cassandra API instance using [DataStax Java Driver 4](https://docs.datastax.com/en/developer/java-driver/4.10/). When you take a dependency on this package, the included `reference.conf` file overrides some of the default values set by [DataStax Java Driver 4](https://docs.datastax.com/en/developer/java-driver/latest/). This ensures a good out-of-box experience for communicating with Cosmos. It guarantees, for example, that each of these extensions are used by default:
+This package provides extensions and a `reference.conf` file for correctly and efficiently accessing a Cosmos DB 
+Cassandra API instance using [DataStax Java Driver 4](https://docs.datastax.com/en/developer/java-driver/4.10/). When 
+you take a dependency on this package, the included `reference.conf` file overrides some of the default values set by 
+[DataStax Java Driver 4](https://docs.datastax.com/en/developer/java-driver/latest/). This ensures a good out-of-box 
+experience for communicating with Cosmos. It guarantees, for example, that each of these extensions are used by default:
 
 - `CosmosLoadBalancingPolicy` provides options for specifying read and write datacenters to route requests.
 - `CosmosRetryPolicy` provides options for back-offs when failures occur.
-- `DefaultSslEngineFactory` secures traffic between the driver and a Cosmos DB Cassandra API instance as required by a Comos DB.
+- `DefaultSslEngineFactory` secures traffic between the driver and a Cosmos DB Cassandra API instance as required by
+  Comos DB.
 
-You can add an `application.conf` file in the classpath (or an absolute path, or a URL) to refine the configuration. It only needs to contain the options that you choose to override.
+You can add an `application.conf` file in the classpath (or an absolute path, or a URL) to refine the configuration. 
+It only needs to contain the options that you choose to override.
 
-The `reference.conf` file is well documented. In the sources, it can be found under [`src/main/resources`](https://github.com/Azure/azure-cosmos-cassandra-extensions/blob/develop/java-driver-4/package/src/main/resources/reference.conf). For a general discussion, see [DataStax Java Driver 4 configuration](https://docs.datastax.com/en/developer/java-driver/4.10/manual/core/configuration/).
+The `reference.conf` file is well documented. In the sources, it can be found under [`src/main/resources`](https://github.com/Azure/azure-cosmos-cassandra-extensions/blob/develop/java-driver-4/package/src/main/resources/reference.conf). 
+For a general discussion, see [DataStax Java Driver 4 configuration](https://docs.datastax.com/en/developer/java-driver/4.10/manual/core/configuration/).
 
 See `KNOWN_ISSUES.md` for a description of known issues in this release.


### PR DESCRIPTION
This is release **0.1.0-beta.1**. It is the  first pre-release of the extensions targeting [DataStax Java Driver 4](https://docs.datastax.com/en/developer/java-driver/latest/) and is tested with driver versions [4.8-4.10].  This fact is captured in the dependencies section of `pom.xml`:
```xml
      <dependency>
        <groupId>com.datastax.oss</groupId>
        <artifactId>java-driver-core</artifactId>
        <version>${version.cassandra-driver}</version>
      </dependency>
```
where
```xml
    <version.cassandra-driver>[4.7,4.11)</version.cassandra-driver>
```

I am preparing this release using the (new) release instructions. See `Release-instructions.md`.