### PR TITLE
[FIX] java-driver-3 | Bump log4j-core from 2.16.0 to 2.17.0

### DIFF
--- a/Release-instructions.md
+++ b/Release-instructions.md
@@ -4,8 +4,8 @@
 - [ ] Create a release branch based on master.
   
       ```bash
-      git pull --all
       git checkout master
+      git pull --all
       git checkout -b release/java-driver-3/$version
       ```
 
@@ -32,7 +32,7 @@
       ```
       [CHORE] Release Azure Cosmos Cassandra Extensions for DataStax Java Driver 3
       ```
-      
+
       Start the description with this text:
       ```
       This is release <version>.

--- a/driver-3/CHANGELOG.md
+++ b/driver-3/CHANGELOG.md
@@ -1,5 +1,18 @@
 ## Release History
 
+## 1.0.3
+
+This is a maintenance release to address the [*Log4j2 Vulnerability “Log4Shell” (CVE-2021-44228)*][1] reported between
+late November and early December 2021. 
+
+### Log4j2 Vulnerability “Log4Shell” (CVE-2021-44228)
+
+The vulnerability that this change addresses is described in the [National Vulnerabilities Database][2]. On 12/17/2021
+Apache released version [Apache log4j2][3] 2.17.0 after discovering issues with their previous release, 2.16.0, 
+published on 12/14/2021. The test and example code in this repository depend on Apache log4j2 and this release bumps 
+the version number for log4j2 from 2.16 to 2.17. The product code takes no dependency on log4j2. It uses [slf4j-api][4] 
+instead.
+
 ## 1.0.2
 
 This is a maintenance release to address the [*Log4j2 Vulnerability “Log4Shell” (CVE-2021-44228)*][1] reported between

--- a/driver-3/pom.xml
+++ b/driver-3/pom.xml
@@ -10,12 +10,12 @@ Licensed under the MIT License.
 
   <artifactId>azure-cosmos-cassandra-driver-3-extensions</artifactId>
   <packaging>jar</packaging>
-  <version>1.0.2</version>
+  <version>1.0.3-SNAPSHOT</version>
 
   <parent>
     <artifactId>azure-cosmos-cassandra-driver-3</artifactId>
     <groupId>com.azure</groupId>
-    <version>1.0.2</version>
+    <version>1.0.3-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/examples/java-driver-app/pom.xml
+++ b/examples/java-driver-app/pom.xml
@@ -10,12 +10,12 @@ Licensed under the MIT License.
 
   <artifactId>azure-cosmos-cassandra-driver-3-examples</artifactId>
   <packaging>jar</packaging>
-  <version>1.0.2</version>
+  <version>1.0.3-SNAPSHOT</version>
 
   <parent>
     <artifactId>azure-cosmos-cassandra-driver-3</artifactId>
     <groupId>com.azure</groupId>
-    <version>1.0.2</version>
+    <version>1.0.3-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@ Licensed under the MIT License.
   <artifactId>azure-cosmos-cassandra-driver-3</artifactId>
   <groupId>com.azure</groupId>
   <packaging>pom</packaging>
-  <version>1.0.2</version>
+  <version>1.0.3-SNAPSHOT</version>
 
   <organization>
     <name>Microsoft Azure Cosmos DB</name>
@@ -58,7 +58,7 @@ Licensed under the MIT License.
     <!-- Test dependency version numbers -->
     <version.assertj-core>3.18.0</version.assertj-core>
     <version.junit-jupiter>5.7.1</version.junit-jupiter>
-    <version.log4j>2.17.0</version.log4j>
+    <version.log4j>[2.17.0,)</version.log4j>
   </properties>
 
   <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@ Licensed under the MIT License.
     <!-- Test dependency version numbers -->
     <version.assertj-core>3.18.0</version.assertj-core>
     <version.junit-jupiter>5.7.1</version.junit-jupiter>
-    <version.log4j>2.16.0</version.log4j>
+    <version.log4j>2.17.0</version.log4j>
   </properties>
 
   <scm>


### PR DESCRIPTION
This change brings the latest security fix for log4j into our example and test code. The product code takes no dependency on log4j.