### PR TITLE
[FIX] java-driver-4 | Bump log4j-core from 2.16.0 to 2.17.0

### DIFF
--- a/Release-instructions.md
+++ b/Release-instructions.md
@@ -33,6 +33,7 @@
 
 - [ ] Bump the version numbers in:
 
+  * Release-instructions.md
   * pom.xml
   * driver-4/pom.xml
   * spring-data/pom.xml

--- a/Release-instructions.md
+++ b/Release-instructions.md
@@ -44,7 +44,7 @@
       
 - [ ] Push your changes and submit a release PR against the code on develop/java-driver-4.
 
-  Use this title text:
+  Use this title text:d
   
   ```text
   [CHORE] Release Azure Cosmos Cassandra Extensions for DataStax Java Driver 4

--- a/Release-instructions.md
+++ b/Release-instructions.md
@@ -44,7 +44,7 @@
       
 - [ ] Push your changes and submit a release PR against the code on develop/java-driver-4.
 
-  Use this title text:d
+  Use this title text:
   
   ```text
   [CHORE] Release Azure Cosmos Cassandra Extensions for DataStax Java Driver 4

--- a/driver-4/CHANGELOG.md
+++ b/driver-4/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Release History
 
+## 1.1.2
+
+This is a maintenance release to address the [*Log4j2 Vulnerability “Log4Shell” (CVE-2021-44228)*][1] reported between
+late November and early December 2021. 
+
+### Log4j2 Vulnerability “Log4Shell” (CVE-2021-44228)
+
+The vulnerability that this change addresses is described in the [National Vulnerabilities Database][2]. On 12/17/2021
+Apache released version [Apache log4j2][3] 2.17.0 after discovering issues with their previous release, 2.16.0, 
+published on 12/14/2021. The test and example code in this repository depend on Apache log4j2 and this release bumps 
+the version number for log4j2 from 2.16 to 2.17. The product code takes no dependency on log4j2. It uses [slf4j-api][4] 
+instead.
+
 ## 1.1.1
 
 This is a maintenance release to address the [*Log4j2 Vulnerability “Log4Shell” (CVE-2021-44228)*][3] reported between 

--- a/driver-4/pom.xml
+++ b/driver-4/pom.xml
@@ -15,12 +15,12 @@ Licensed under the MIT License.
 
   <artifactId>azure-cosmos-cassandra-driver-4-extensions</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.1</version>
+  <version>1.1.2-SNAPSHOT</version>
 
   <parent>
     <artifactId>azure-cosmos-cassandra-driver-4</artifactId>
     <groupId>com.azure</groupId>
-    <version>1.1.1</version>
+    <version>1.1.2-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/driver-4/pom.xml
+++ b/driver-4/pom.xml
@@ -15,12 +15,12 @@ Licensed under the MIT License.
 
   <artifactId>azure-cosmos-cassandra-driver-4-extensions</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.1-SNAPSHOT</version>
+  <version>1.1.1</version>
 
   <parent>
     <artifactId>azure-cosmos-cassandra-driver-4</artifactId>
     <groupId>com.azure</groupId>
-    <version>1.1.1-SNAPSHOT</version>
+    <version>1.1.1</version>
   </parent>
 
   <dependencies>

--- a/driver-4/src/main/resources/reference.conf
+++ b/driver-4/src/main/resources/reference.conf
@@ -97,7 +97,7 @@ datastax-java-driver {
       # A request timeout of 5 seconds provides a better out-of-box experience than the default value of 2 seconds.
       # Adjust this value up or down based on workload and Cosmos Cassandra througput provisioning. The more
       # throughput you provision, the lower you might set this value.
-      timeout = 5 seconds
+      timeout = 90 seconds
     }
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@ Licensed under the MIT License.
   <artifactId>azure-cosmos-cassandra-driver-4</artifactId>
   <groupId>com.azure</groupId>
   <packaging>pom</packaging>
-  <version>1.1.1</version>
+  <version>1.1.2-SNAPSHOT</version>
 
   <developers>
     <developer>
@@ -48,7 +48,7 @@ Licensed under the MIT License.
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <javadoc.options/>
     <!-- Package dependency version numbers -->
-    <version.cassandra-driver>[4.7,4.13)</version.cassandra-driver>
+    <version.cassandra-driver>[4.7,4.14)</version.cassandra-driver>
     <version.jackson>[2.12,2.13)</version.jackson>
     <version.slf4j-api>[1.7,1.8.0-alpha0)</version.slf4j-api>
     <version.spring-data-cassandra>[3.2,3.3)</version.spring-data-cassandra>
@@ -57,7 +57,7 @@ Licensed under the MIT License.
     <!-- Test dependency version numbers -->
     <version.assertj-core>3.18.0</version.assertj-core>
     <version.junit-jupiter>5.7.1</version.junit-jupiter>
-    <version.log4j>2.17.0</version.log4j>
+    <version.log4j>[2.17.0,)</version.log4j>
     <version.testng>7.3.0</version.testng>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@ Licensed under the MIT License.
     <!-- Test dependency version numbers -->
     <version.assertj-core>3.18.0</version.assertj-core>
     <version.junit-jupiter>5.7.1</version.junit-jupiter>
-    <version.log4j>2.15.0</version.log4j>
+    <version.log4j>2.17.0</version.log4j>
     <version.testng>7.3.0</version.testng>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@ Licensed under the MIT License.
   <artifactId>azure-cosmos-cassandra-driver-4</artifactId>
   <groupId>com.azure</groupId>
   <packaging>pom</packaging>
-  <version>1.1.1-SNAPSHOT</version>
+  <version>1.1.1</version>
 
   <developers>
     <developer>

--- a/spring-data/pom.xml
+++ b/spring-data/pom.xml
@@ -15,12 +15,12 @@ Licensed under the MIT License.
 
   <artifactId>azure-cosmos-cassandra-spring-data-extensions</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.1-SNAPSHOT</version>
+  <version>1.1.1</version>
 
   <parent>
     <artifactId>azure-cosmos-cassandra-driver-4</artifactId>
     <groupId>com.azure</groupId>
-    <version>1.1.1-SNAPSHOT</version>
+    <version>1.1.1</version>
   </parent>
 
   <dependencies>

--- a/spring-data/pom.xml
+++ b/spring-data/pom.xml
@@ -15,12 +15,12 @@ Licensed under the MIT License.
 
   <artifactId>azure-cosmos-cassandra-spring-data-extensions</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.1</version>
+  <version>1.1.2-SNAPSHOT</version>
 
   <parent>
     <artifactId>azure-cosmos-cassandra-driver-4</artifactId>
     <groupId>com.azure</groupId>
-    <version>1.1.1</version>
+    <version>1.1.2-SNAPSHOT</version>
   </parent>
 
   <dependencies>


### PR DESCRIPTION
This change brings the latest security fix for log4j into our example and test code. The product code takes no dependency on log4j.