### PR TITLE
[CHORE] Bump azure-cosmos-cassandra-spring-data-extensions version number to 1.1.2-1

### DIFF
--- a/spring-data/CHANGELOG.md
+++ b/spring-data/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.1.2
+## 1.1.2-1
 
 This release bumps the version of the dependency on `azure-cosmos-cassandra-driver-4-extensions` from 1.1.1 to 1.1.2.
 See the [`CHANGELOG.md`][4] for a summary of the changes to this dependency.

--- a/spring-data/pom.xml
+++ b/spring-data/pom.xml
@@ -10,12 +10,13 @@ Licensed under the MIT License.
 
   <name>Azure Cosmos Extensions for Spring Data for Apache Cassandra</name>
   <description>
-    Extends the Spring Data for Apache Cassandra client library with Azure Cosmos awareness features.
+    Extends the Spring Data for Apache Cassandra client library with Azure Cosmos awareness features. This release
+    corrects and replaces release 1.1.2, which contains a publishing error.
   </description>
 
   <artifactId>azure-cosmos-cassandra-spring-data-extensions</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.2</version>
+  <version>1.1.2-1</version>
 
   <parent>
     <artifactId>azure-cosmos-cassandra-driver-4</artifactId>
@@ -27,6 +28,7 @@ Licensed under the MIT License.
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-cosmos-cassandra-driver-4-extensions</artifactId>
+      <version>${parent.version}</version>
       <scope>compile</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
This release will correct a Maven repository publishing error. There are no code changes. We merely bump the version number in azure-cosmos-cassandra-spring-data-extensions from 1.1.2 to 1.1.2-1 due to a maven repository publication error. We would have preferred to remove and republish, but packages published to the Maven repository are immutable.